### PR TITLE
fix: Use of undefined variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 before_script:
-  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git cobalt-org/cobalt.rs --crate cobalt --force --target x86_64-unknown-linux-gnu
+  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git cobalt-org/cobalt.rs --crate cobalt --force --target x86_64-unknown-linux-gnu --tag v0.9.0
   - export PATH="$PATH:~/.cargo/bin"
 script:
   - cobalt build

--- a/license.md
+++ b/license.md
@@ -1,6 +1,7 @@
 extends: default.liquid
 
 title: johannh.me - License
+route: about
 path:  license/
 ---
 


### PR DESCRIPTION
For now, cobalt is becoming stricter on the user of undefined variables to help catch problems when migrating sites through https://github.com/cobalt-org/cobalt.rs/pull/346.

With this PR, your site correctly builds against 346 after running `cobalt migrate`.  Hopefully my guesses for how to change your site are close enough :).

I will follow up with a PR that migrates your site once 346 is dev complete.  Feel free to start playing with it and providing feedback (particularly around https://github.com/cobalt-org/cobalt.rs/issues/323).